### PR TITLE
Upgrade python to v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
         apt-get update && \
         apt-get install -y \
             kubectl \
-            python-pip \
+            python3-pip \
             jshon \
         && \
         apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -19,10 +19,9 @@ RUN apt-get update && \
 RUN curl https://get.docker.com | bash -
 RUN usermod -aG docker jenkins
 
-RUN pip install \
+RUN pip3 install \
         awscli \
         boto \
-        pyrsistent==0.16.1 \
         docker-compose
 
 RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator && chmod +x /usr/local/bin/aws-iam-authenticator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  jenkins:
+    build:
+      context: .
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
switch to version 3 of python for awscli, dcoker-compose etc 

this change removes the locked dep from #5 and adds a docker-compose file for testing the build and startup of jenkins, e.g. 
- `docker-compose build`
- `docker-compose up`